### PR TITLE
refactor: BREAKING - cleanup README and simplify API base URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### 1. Add This Server to Claude Code
 
-In your project directory where you want to use LM Studio, add this MCP server directly from GitHub:
+Add this MCP server directly from GitHub:
 
 ```bash
 claude mcp add lmstudio-mcp -- npx github:nyvyn/lmstudio-mcp
@@ -84,8 +84,6 @@ npm run build
 ### Utility Tools
 
 - **`echo`** - Echo back provided text
-- **`add`** - Add two numbers together
-- **`get_system_info`** - Get basic system information
 
 ## 🏃‍♂️ Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import fetch from "node-fetch";
 
-const LM_STUDIO_BASE_URL = "http://localhost:1234/v1";
+const LM_STUDIO_BASE_URL = "http://localhost:1234";
+const V1 = "/v1"; // Version of the LM Studio API
 
 const server = new McpServer({
   name: "lmstudio-mcp",
@@ -13,7 +14,7 @@ const server = new McpServer({
 });
 
 async function makeRequest(endpoint: string, options: any = {}): Promise<any> {
-  const response = await fetch(`${LM_STUDIO_BASE_URL}${endpoint}`, {
+  const response = await fetch(`${LM_STUDIO_BASE_URL}${V1}${endpoint}`, {
     headers: {
       'Content-Type': 'application/json',
       ...options.headers


### PR DESCRIPTION
- Remove outdated utilities from README.
- Simplify API base URL definition by separating version path in `src/index.ts`.